### PR TITLE
Remove the unused use statement

### DIFF
--- a/inc/utils.php
+++ b/inc/utils.php
@@ -1,7 +1,5 @@
 <?php
 
-use \Uploadcare;
-
 /**
  * Get Api object
  *


### PR DESCRIPTION
Hello guys,

I'd like to propose the removal of Line 3 of `inc/utils.php`:
```php
use \Uploadcare;
```
as it triggers a PHP warning: The use statement with non-compound name '\Uploadcare' has no effect.

Please review :smiley: