### PR TITLE
fixes for wp 7.4.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 ## Changelog
+**2.4.1**
+* Minor bug fix for usage jQuery.
+* Test up to Wordpress 4.7.2
 
 **2.4.0** ([Download](http://downloads.wordpress.org/plugin/uploadcare.2.4.0.zip))
 * Uploadcare widget updated to version 2.6.0

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 ## Changelog
-**2.4.1**
+**2.4.1** ([Download](http://downloads.wordpress.org/plugin/uploadcare.2.4.1.zip))
 * Minor bug fix for usage jQuery.
 * Test up to Wordpress 4.7.2
 

--- a/js/main.js
+++ b/js/main.js
@@ -27,7 +27,7 @@ function ucStoreImg(fileInfo, callback) {
 function ucAddImg(fileInfo) {
   ucStoreImg(fileInfo, function(response) {
     if (fileInfo.isImage) {
-      var $img = '<img src="' + fileInfo.cdnUrl + '\" alt="' + fileInfo.name + '"/>';
+      var $img = '<img src="' + fileInfo.cdnUrl + '" alt="' + fileInfo.name + '"/>';
       if(UPLOADCARE_CONF.original) {
         window.send_to_editor('<a href="' + fileInfo.cdnUrl + '">' + $img + '</a>');
       } else {

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function ucEditFile(file_id) {
   try {
     tb_remove();
@@ -15,7 +17,7 @@ function ucStoreImg(fileInfo, callback) {
     'action': 'uploadcare_handle',
     'file_id': fileInfo.uuid
   };
-  jQuery.post(ajaxurl, data, function(response) {
+  uploadcare.jQuery.post(ajaxurl, data, function(response) {
     if (callback) {
       callback(response);
     }
@@ -27,19 +29,19 @@ function ucAddImg(fileInfo) {
     if (fileInfo.isImage) {
       var $img = '<img src="' + fileInfo.cdnUrl + '\" alt="' + fileInfo.name + '"/>';
       if(UPLOADCARE_CONF.original) {
-        window.send_to_editor('<a href="' + UPLOADCARE_CDN_BASE + fileInfo.uuid + '/">' + $img + '</a>');
+        window.send_to_editor('<a href="' + fileInfo.cdnUrl + '">' + $img + '</a>');
       } else {
         window.send_to_editor($img);
       }
     } else {
-      window.send_to_editor('<a href="' + fileInfo.cdnUrl + '\">' + fileInfo.name + '</a>');
+      window.send_to_editor('<a href="' + fileInfo.cdnUrl + '">' + fileInfo.name + '</a>');
     }
     window.send_to_editor('\n');
   });
 }
 
 function ucFileDone(data) {
-  jQuery('#content').prop('disabled', true);
+  uploadcare.jQuery('#content').prop('disabled', true);
   if(UPLOADCARE_MULTIPLE) {
     data.promise().done(function(fileGroupInfo) {
       var files = data.files();
@@ -50,13 +52,13 @@ function ucFileDone(data) {
         });
       }
     }).always(function() {
-      jQuery('#content').prop('disabled', false);
+      uploadcare.jQuery('#content').prop('disabled', false);
     });
   } else {
     var file = data;
     file.done(ucAddImg)
         .always(function() {
-          jQuery('#content').prop('disabled', false);
+          uploadcare.jQuery('#content').prop('disabled', false);
         });
   }
 }
@@ -83,7 +85,7 @@ function ucPostUploadUiBtn() {
             }
             if(wp.media) {
               // select attachment
-              var obj = jQuery.parseJSON(response);
+              var obj = uploadcare.jQuery.parseJSON(response);
               var selection = wp.media.frame.state().get('selection'),
               attachment = wp.media.attachment(obj.attach_id);
               attachment.fetch();
@@ -110,11 +112,11 @@ function ucPostUploadUiBtn() {
   });
 }
 
-jQuery(function() {
+uploadcare.jQuery(function() {
   // add button to all inputs with .uploadcare-url-field
-  jQuery('input.uploadcare-url-field').each(function() {
-    var input = jQuery(this);
-    var img = jQuery('<img />');
+  uploadcare.jQuery('input.uploadcare-url-field').each(function() {
+    var input = uploadcare.jQuery(this);
+    var img = uploadcare.jQuery('<img />');
     var preview = function() {
       if(input.val().length > 0) {
         img.attr('src', input.val() + '-/preview/300x300/');
@@ -122,7 +124,7 @@ jQuery(function() {
     };
     input.before(img);
     preview();
-    input.after(jQuery('<a class="button"><span>uc</span></a>').on('click', function() {
+    input.after(uploadcare.jQuery('<a class="button"><span>uc</span></a>').on('click', function() {
       uploadcare.openDialog(null, {multiple: false}).done(function(data) {
         data.done(function(fileInfo) {
           ucStoreImg(fileInfo, function() {
@@ -135,8 +137,8 @@ jQuery(function() {
   });
 
   // featured image stuff
-  var addLink = jQuery('#uc-set-featured-img');
-  var removeLink = jQuery('#uc-remove-featured-img');
+  var addLink = uploadcare.jQuery('#uc-set-featured-img');
+  var removeLink = uploadcare.jQuery('#uc-remove-featured-img');
 
   function setImg() {
     var url = addLink.data('uc-url');
@@ -160,7 +162,7 @@ jQuery(function() {
       data.done(function(fileInfo) {
         ucStoreImg(fileInfo, function() {
           addLink.data('uc-url', fileInfo.cdnUrl);
-          jQuery('#uc-featured-image-input').val(fileInfo.cdnUrl);
+          uploadcare.jQuery('#uc-featured-image-input').val(fileInfo.cdnUrl);
           setImg();
         });
       });
@@ -168,7 +170,7 @@ jQuery(function() {
   });
 
   removeLink.click(function() {
-    jQuery('#uc-featured-image-input').val('');
+    uploadcare.jQuery('#uc-featured-image-input').val('');
     addLink.data('uc-url', '');
     setImg();
   });
@@ -176,9 +178,9 @@ jQuery(function() {
   setImg();
 
   // media tab
-  jQuery('#uploadcare-more').on('click', function() {
-    jQuery('#uploadcare-more-container').hide();
-    jQuery('#uploadcare-lib-container').hide();
+  uploadcare.jQuery('#uploadcare-more').on('click', function() {
+    uploadcare.jQuery('#uploadcare-more-container').hide();
+    uploadcare.jQuery('#uploadcare-lib-container').hide();
     uploadcare.openPanel('#uploadcare-panel-container', [], {
       multiple: true,
       autostore: true

--- a/js/main.js
+++ b/js/main.js
@@ -84,12 +84,26 @@ function ucPostUploadUiBtn() {
               }
             }
             if(wp.media) {
-              // select attachment
               var obj = uploadcare.jQuery.parseJSON(response);
-              var selection = wp.media.frame.state().get('selection'),
-              attachment = wp.media.attachment(obj.attach_id);
+              var attachment = wp.media.attachment(obj.attach_id);
               attachment.fetch();
-              selection.add(attachment);
+              var library = null;
+              switch(wp.media.frame._state) {
+                case 'insert':
+                case 'gallery':
+                case 'featured-image':
+                case 'library':
+                  wp.media.frame.content.mode('browse');
+                  library = wp.media.frame.content.mode('library').get().collection;
+                break;
+                case 'edit-attachment':
+                  library = wp.media.frame.content.mode('library').view.library;
+                break;
+              }
+
+              if(library) {
+                library.add(attachment);
+              }
             }
             stored++;
             if(stored == files.length) {
@@ -99,8 +113,12 @@ function ucPostUploadUiBtn() {
               if(wp.media) {
                 // switch to attachment browser
                 wp.media.frame.content.mode('browse');
+
                 // refresh attachment collection
-                updateAttachments();
+                // no need for WP 4.7.2 but kept for older WP versions
+                try {
+                  updateAttachments();
+                } catch(ex) {}
               } else if (adminpage == 'media-new-php') {
                 location = 'upload.php';
               }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: grayhound1, dmitry-mukhin
 Tags: media upload, file handling, cdn, storage, facebook, dropbox, instagram, google drive, vk, evernote, box, images, flickr
 Requires at least: 3.5+
-Tested up to: 4.4.2
+Tested up to: 4.7.2
 Stable tag: 2.4.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,10 @@ Access all files in your Uploadcare account via Media Library.
 
 == Changelog ==
 
+= 2.4.1 =
+* Minor bug fix for usage jQuery.
+* Test up to Wordpress 4.7.2
+
 = 2.4.0 =
 * Uploadcare widget updated to version 2.6.0
 * Test up to Wordpress 4.4.2

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: grayhound1, dmitry-mukhin
 Tags: media upload, file handling, cdn, storage, facebook, dropbox, instagram, google drive, vk, evernote, box, images, flickr
 Requires at least: 3.5+
 Tested up to: 4.7.2
-Stable tag: 2.4.0
+Stable tag: 2.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://uploadcare.com/pricing/

--- a/uploadcare.php
+++ b/uploadcare.php
@@ -3,7 +3,7 @@
 Plugin Name: Uploadcare
 Plugin URI: http://github.com/uploadcare/uploadcare-wordpress
 Description: Uploadcare let's you upload anything from anywhere (Instagram, Facebook, Dropbox, etc.)
-Version: 2.5.1
+Version: 2.4.1
 Author: Uploadcare
 Author URI: https://uploadcare.com/
 License: GPL2
@@ -14,7 +14,7 @@ if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
     exit("Uploadcare plugin requires PHP version <b>5.3+</b>, you've got <b>" . PHP_VERSION . "</b>");
 }
 
-define('UPLOADCARE_PLUGIN_VERSION', '2.5.1');
+define('UPLOADCARE_PLUGIN_VERSION', '2.4.1');
 define('UPLOADCARE_WIDGET_VERSION', '2.x');
 
 define('UPLOADCARE_PLUGIN_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
Fixed following parts:

- [x] Inline image insert
- [x] Use only widget jQuery

надо проверить на последней верии WP, и соответственно обновить

- [x] readme.txt
- [x] uploadcare.php
- [x] changelog.md
