### PR TITLE
Added  PHP 8+ support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,18 @@ on:
 jobs:
     tag:
         name: Upload Plugin to WP SVN
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
+        strategy:
+          fail-fast: true
+          matrix:
+            php-versions: [ "7.4", "8.0", "8.1" ]
         steps:
             -   name: Checkout Repo
                 uses: actions/checkout@v2
             -   name: Install dependencies
                 uses: php-actions/composer@v5
                 with:
-                    php_version: 7.1
+                    php_version: "${{ matrix.php-versions }}"
                     dev: no
             -   name: Install npm dependencies
                 run: |

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,4 +8,4 @@ Elijah <ilya@uploadcare.com>
 Igor Debatur <igor@uploadcare.com>
 Roman Sedykh <https://github.com/rsedykh>
 Siarhei Bautrukevich <s.boltrukevich@gmail.com>
-
+Mikhail Khasaya <https://github.com/dillix>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.0.9] — 2022-12-10
 
 * Added php 8.1 support
-* Bumped minimal php version to 7.4
+* Bumped minimal PHP version to 7.4.
 
 ## [3.0.8] — 2022-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based now on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.9] — 2022-12-10
+
+* Added php 8.1 support
+* Bumped minimal php version to 7.4
+
 ## [3.0.8] — 2022-01-24
 
 * Removed types from method (bug fix for https://wordpress.org/support/topic/fatal-error-3-0-7/).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.0.9] — 2022-12-10
 
-* Added php 8.1 support
+* Added PHP 8.1 support.
 * Bumped minimal PHP version to 7.4.
 
 ## [3.0.8] — 2022-01-24

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Uploadcare, all-round media upload, storage, management, and delivery solution, 
 ## Requirements
 
 - Wordpress 5+
-- PHP 7.1+
+- PHP 7.4+
 - php-curl
 - php-json
 - php-dom

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
   "name": "uploadcare/uploadcare-wordpress",
   "require": {
-    "php": "^7.1",
+    "php": ">=7.4 || >=8.0",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-dom": "*",
-    "uploadcare/uploadcare-php": "^3.0",
-    "symfony/dom-crawler": "^3.4",
+    "uploadcare/uploadcare-php": "^3.1",
+    "symfony/dom-crawler": "^5.4",
     "twig/twig": "^2.13|^3.0"
   },
   "autoload": {
@@ -18,7 +18,7 @@
         }
     },
   "require-dev": {
-    "phpunit/phpunit": "^7",
-    "symfony/var-dumper": "^4.4"
+    "phpunit/phpunit": "^7||^9",
+    "symfony/var-dumper": "^4.4||^5"
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
 === Uploadcare File Uploader and Adaptive Delivery ===
 
-Contributors: andrew72ru, rsedykh
+Contributors: andrew72ru, rsedykh, mixar
 Tags: file upload, cdn, storage, adaptive delivery, responsive, lazy loading, optimization, performance
 Requires at least: 5.0
-Tested up to: 5.7.2
-Requires PHP: 7.1
-Stable tag: 3.0.8
+Tested up to: 6.1.1
+Requires PHP: 7.4
+Stable tag: 3.0.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://uploadcare.com/pricing/
@@ -96,7 +96,7 @@ Send us your feedback, <help@uploadcare.com>
 ### Requirements ###
 
 * Wordpress 5+
-* PHP 7.1+
+* PHP 7.4+
 * php-curl
 * php-json
 * php-dom
@@ -111,6 +111,9 @@ Send us your feedback, <help@uploadcare.com>
 6. Transfer existing Media Library to Uploadcare.
 
 == Upgrade Notice ==
+
+= 3.0.9 =
+Minimal PHP version bumped to 7.4.
 
 = 3.0.0 =
 Brand new plug-in, rewritten from scratch. Note that forks from older plugins (v2.*) won't be compatible with the new version. In addition to uploading files it now supports Adaptive Delivery which improves image appearance on all devices and increases page load speed. Transfer Media Library files to your Uploadcare storage. Intuitive settings.
@@ -131,6 +134,11 @@ Upgrade if you are using Uploadcare for Featured Images.
 Access all files in your Uploadcare account via Media Library.
 
 == Changelog ==
+
+= 3.0.9 =
+
+* Added support for PHP 8+.
+* Bumped minimal PHP version to 7.4.
 
 = 3.0.8
 

--- a/uploadcare.php
+++ b/uploadcare.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Uploadcare File Uploader and Adaptive Delivery
  * Plugin URI:        https://github.com/uploadcare/uploadcare-wordpress
  * Description:       Upload and store any file of any size from any device or cloud. No more slow downs when serving your images with automatic responsiviness and lazy loading. Improve your WP performance to boost Customer Experience and SEO.
- * Version:           3.0.8
+ * Version:           3.0.9
  * Author:            Uploadcare
  * Author URI:        https://uploadcare.com/
  * License:           GPL-2.0+
@@ -19,15 +19,15 @@
  */
 class Uploadcare_Wordpress_Plugin
 {
-    public const UPLOADCARE_VERSION = '3.0.8';
+    public const UPLOADCARE_VERSION = '3.0.9';
 
     public function __construct()
     {
         if (!\defined('WPINC')) {
             exit();
         }
-        if (PHP_VERSION_ID < 70100) {
-            exit("Uploadcare plugin requires PHP version <b>7.1+</b>, you've got <b>" . PHP_VERSION . '</b>');
+        if (PHP_VERSION_ID < 70400) {
+            exit("Uploadcare plugin requires PHP version <b>7.4.0+</b>, you've got <b>" . PHP_VERSION . '</b>');
         }
         \defined('UPLOADCARE_VERSION') or \define('UPLOADCARE_VERSION', self::UPLOADCARE_VERSION);
 


### PR DESCRIPTION
I added PHP 8+ support for uploadcare Wordpress plugin. Minimal PHP version was bumped to 7.4 due to dependencies and preparation to release with uploadcare-php 4.0.x library. This build was successfully tested on PHP 8.1.